### PR TITLE
Branch sort by favourite

### DIFF
--- a/src/test/java/seedu/address/logic/commands/MarkAsFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAsFavouriteCommandTest.java
@@ -49,9 +49,6 @@ public class MarkAsFavouriteCommandTest {
         List<Person> lastShownList = model.getFilteredPersonList();
         Person personToEdit = lastShownList.get(index.getZeroBased());
 
-        assertCommandSuccess(secondCommand, model,
-                String.format(MarkAsFavouriteCommand.MESSAGE_MARK_PERSON_DUPLICATE,
-                        personToEdit.getName()), model);
         assertCommandFailure(secondCommand, model,
                 String.format(MarkAsFavouriteCommand.MESSAGE_MARK_PERSON_DUPLICATE,
                         personToEdit.getName()));

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -18,8 +18,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
-import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.PersonBuilder;
+
 
 public class ModelManagerTest {
 


### PR DESCRIPTION
# Add Sorting by favourites
- Ensures that for all favourites are always at the top of all displayed lists
- Implemented by using a comparator that sorts via person::getIsFavourite() followed by normal natural order of name