### PR TITLE
Fix CLIentTracker crashing when stored meeting date before system date

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -147,6 +147,8 @@ class JsonAdaptedPerson {
                 modelMeeting = new Meeting(LocalDateTime.parse(meeting));
             } catch (DateTimeParseException exception) {
                 throw new IllegalValueException("Meeting date/time must be stored in ISO-8601 format.");
+            } catch (IllegalArgumentException exception) {
+                modelMeeting = null;
             }
         }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -173,11 +173,12 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_pastMeetingDate_throwsIllegalArgumentException() {
+    public void toModelType_pastMeetingDate_returnsPersonWithoutMeeting() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_DETAILS, VALID_TAGS,
                 NOT_FAVOURITE, "2020-01-01T10:00");
-        assertThrows(IllegalArgumentException.class, person::toModelType);
+        Person modelPerson = person.toModelType();
+        assertFalse(modelPerson.hasMeeting());
     }
 
 


### PR DESCRIPTION
App now creates Person with null for meeting when stored meeting date is before current system date.