### PR TITLE
Update the delete error message and user guide to be more consistent

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -273,7 +273,7 @@ Format: `delete PHONE`
 
 * Deletes the person with `PHONE`.
   * The PHONE refers to the index number shown in the displayed person list.
-  * The PHONE **must consist of 8 positive integer** 91234567, 01010101…​
+  * The PHONE **must match fully  **​
   * Confirm with y/n after delete command was entered
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -19,11 +19,11 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person based on their contact number.\n"
-            + "Parameters: Phone Number (must be 8 digits)\n"
+            + "Parameters: Ensure Phone Number matches exactly \n"
             + "Example: " + COMMAND_WORD + " 91234567";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-    public static final String MESSAGE_PHONE_NOT_FOUND = "No person found with phone number: %1$s";
+    public static final String MESSAGE_PHONE_NOT_FOUND = "No person found with this specific phone number: %1$s";
     public static final String MESSAGE_CONFIRMATION_PROMPT = "Are you sure you want to delete this contact? %1$s (y/n)";
     public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please enter 'y' to confirm or 'n' to cancel.";
     public static final String MESSAGE_DELETION_CANCELLED = "Deletion cancelled.";


### PR DESCRIPTION
Updates the delete command error message and user guide documentation for consistency and clarity.
Refined error message for the delete command to clearly state when a phone number is not found.
