### PR TITLE
Improve meeting cleanup notifications and confirmation handling

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -22,7 +22,6 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
-import seedu.address.storage.AddressBookStorage;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
@@ -45,6 +44,7 @@ public class MainApp extends Application {
     protected Storage storage;
     protected Model model;
     protected Config config;
+    private String startupNotification;
 
     @Override
     public void init() throws Exception {
@@ -57,14 +57,28 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         model = initModelManager(storage, userPrefs);
 
         logic = new LogicManager(model, storage);
 
-        ui = new UiManager(logic);
+        setPastMeetingNotification(addressBookStorage);
+        ui = new UiManager(logic, Optional.ofNullable(startupNotification));
+    }
+
+    private void setPastMeetingNotification(JsonAddressBookStorage addressBookStorage) {
+        int count = addressBookStorage.getRemovedPastMeetingCount();
+        if (count == 0) {
+            return;
+        }
+        startupNotification = count + " past meeting(s) removed.";
+        try {
+            storage.saveAddressBook(model.getAddressBook());
+        } catch (IOException e) {
+            logger.warning("Failed to save address book after removing past meetings: " + StringUtil.getDetails(e));
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -54,7 +54,7 @@ public class LogicManager implements Logic {
         if (DeleteCommand.hasPendingConfirmation()) {
             AddressBook previousState = null;
             String executedCommandText = null;
-            if (commandText.equalsIgnoreCase("y")) {
+            if (commandText.trim().equalsIgnoreCase("y")) {
                 previousState = new AddressBook(model.getAddressBook());
                 executedCommandText = DeleteCommand.getPendingCommandText();
             }
@@ -69,7 +69,7 @@ public class LogicManager implements Logic {
         if (ClearCommand.hasPendingConfirmation()) {
             AddressBook previousState = null;
             String executedCommandText = null;
-            if (commandText.equalsIgnoreCase("y")) {
+            if (commandText.trim().equalsIgnoreCase("y")) {
                 previousState = new AddressBook(model.getAddressBook());
                 executedCommandText = ClearCommand.getPendingCommandText();
             }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,7 +18,8 @@ public class ClearCommand extends Command {
             + "Example: " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_CONFIRMATION_PROMPT = "Are you sure you want to clear your contact book? (y/n)";
-    public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please enter 'y' to confirm or 'n' to cancel.";
+    public static final String MESSAGE_CONFIRMATION_REQUIRED =
+            "All commands are locked until confirmation is done. Please enter 'y' to confirm or 'n' to cancel.";
     public static final String MESSAGE_CLEAR_CANCELLED = "Clear cancelled.";
 
     private static ClearCommand pendingClearCommand;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -25,7 +25,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_PHONE_NOT_FOUND = "No person found with this specific phone number: %1$s";
     public static final String MESSAGE_CONFIRMATION_PROMPT = "Are you sure you want to delete this contact? %1$s (y/n)";
-    public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please enter 'y' to confirm or 'n' to cancel.";
+    public static final String MESSAGE_CONFIRMATION_REQUIRED =
+            "All commands are locked until confirmation is done. Please enter 'y' to confirm or 'n' to cancel.";
     public static final String MESSAGE_DELETION_CANCELLED = "Deletion cancelled.";
 
     private static DeleteCommand pendingDeleteCommand;

--- a/src/main/java/seedu/address/logic/commands/MeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetingCommand.java
@@ -30,6 +30,7 @@ public class MeetingCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 25/03/2030 14:30\n"
             + "Example: " + COMMAND_WORD + " 1 " + CLEAR_KEYWORD + "\n"
             + DateTimeUtil.MESSAGE_INVALID_DATE_TIME_FORMAT;
+    public static final String MESSAGE_NO_MEETINGS = "There are currently no scheduled meetings for %1$s";
 
     private final Index index;
     private final Meeting meeting;
@@ -87,6 +88,10 @@ public class MeetingCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        if (isClearMeeting && !personToEdit.hasMeeting()) {
+            return new CommandResult(String.format(MESSAGE_NO_MEETINGS, personToEdit.getName()));
+        }
+
         Person updatedPerson = new Person(
                 personToEdit.getName(),
                 personToEdit.getPhone(),

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -36,6 +36,7 @@ class JsonAdaptedPerson {
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
     private final boolean isFavourite;
     private final String meeting;
+    private boolean removedPastMeeting;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -143,11 +144,14 @@ class JsonAdaptedPerson {
 
         Meeting modelMeeting = null;
         if (meeting != null) {
+            LocalDateTime parsedMeeting = null;
             try {
-                modelMeeting = new Meeting(LocalDateTime.parse(meeting));
+                parsedMeeting = LocalDateTime.parse(meeting);
+                modelMeeting = new Meeting(parsedMeeting);
             } catch (DateTimeParseException exception) {
                 throw new IllegalValueException("Meeting date/time must be stored in ISO-8601 format.");
             } catch (IllegalArgumentException exception) {
+                removedPastMeeting = parsedMeeting.isBefore(LocalDateTime.now());
                 modelMeeting = null;
             }
         }
@@ -156,4 +160,7 @@ class JsonAdaptedPerson {
                 modelTags, modelIsFavourite, modelMeeting);
     }
 
+    public boolean hasRemovedPastMeeting() {
+        return removedPastMeeting;
+    }
 }

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -22,6 +22,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
 
     private Path filePath;
+    private int removedPastMeetingCount;
 
     public JsonAddressBookStorage(Path filePath) {
         this.filePath = filePath;
@@ -48,15 +49,22 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
                 filePath, JsonSerializableAddressBook.class);
         if (!jsonAddressBook.isPresent()) {
+            removedPastMeetingCount = 0;
             return Optional.empty();
         }
 
         try {
-            return Optional.of(jsonAddressBook.get().toModelType());
+            ReadOnlyAddressBook addressBook = jsonAddressBook.get().toModelType();
+            removedPastMeetingCount = jsonAddressBook.get().getRemovedPastMeetingCount();
+            return Optional.of(addressBook);
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataLoadingException(ive);
         }
+    }
+
+    public int getRemovedPastMeetingCount() {
+        return removedPastMeetingCount;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -22,6 +22,7 @@ class JsonSerializableAddressBook {
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private int removedPastMeetingCount;
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
@@ -47,14 +48,20 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
+        removedPastMeetingCount = 0;
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();
             if (addressBook.hasPerson(person)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
+            removedPastMeetingCount += jsonAdaptedPerson.hasRemovedPastMeeting() ? 1 : 0;
             addressBook.addPerson(person);
         }
         return addressBook;
+    }
+
+    public int getRemovedPastMeetingCount() {
+        return removedPastMeetingCount;
     }
 
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -29,6 +30,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
+    private Optional<String> startupNotification;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -54,11 +56,19 @@ public class MainWindow extends UiPart<Stage> {
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
     public MainWindow(Stage primaryStage, Logic logic) {
+        this(primaryStage, logic, Optional.empty());
+    }
+
+    /**
+     * Creates a {@code MainWindow} with the given startup notification.
+     */
+    public MainWindow(Stage primaryStage, Logic logic, Optional<String> startupNotification) {
         super(FXML, primaryStage);
 
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
+        this.startupNotification = startupNotification;
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
@@ -114,6 +124,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
+        startupNotification.ifPresent(resultDisplay::setFeedbackToUser);
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import javafx.application.Platform;
@@ -24,12 +25,21 @@ public class UiManager implements Ui {
 
     private Logic logic;
     private MainWindow mainWindow;
+    private Optional<String> startupNotification;
 
     /**
      * Creates a {@code UiManager} with the given {@code Logic}.
      */
     public UiManager(Logic logic) {
+        this(logic, Optional.empty());
+    }
+
+    /**
+     * Creates a {@code UiManager} with the given startup notification.
+     */
+    public UiManager(Logic logic, Optional<String> startupNotification) {
         this.logic = logic;
+        this.startupNotification = startupNotification;
     }
 
     @Override
@@ -40,7 +50,7 @@ public class UiManager implements Ui {
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
 
         try {
-            mainWindow = new MainWindow(primaryStage, logic);
+            mainWindow = new MainWindow(primaryStage, logic, startupNotification);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
 

--- a/src/test/java/seedu/address/MainAppTest.java
+++ b/src/test/java/seedu/address/MainAppTest.java
@@ -1,0 +1,98 @@
+package seedu.address;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.model.ModelManager;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.StorageManager;
+
+public class MainAppTest {
+
+    @TempDir
+    public Path temporaryFolder;
+
+    @Test
+    public void setPastMeetingNotification_noRemovedMeetings_noNotification() throws Exception {
+        MainApp mainApp = createMainApp();
+        invokeSetPastMeetingNotification(mainApp, new JsonAddressBookStorage(temporaryFolder.resolve("ab.json")));
+
+        assertNull(getStartupNotification(mainApp));
+    }
+
+    @Test
+    public void setPastMeetingNotification_removedMeetings_setsNotification() throws Exception {
+        MainApp mainApp = createMainApp();
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(temporaryFolder.resolve("ab.json")) {
+            @Override
+            public int getRemovedPastMeetingCount() {
+                return 2;
+            }
+        };
+
+        invokeSetPastMeetingNotification(mainApp, addressBookStorage);
+
+        assertEquals("2 past meeting(s) removed.", getStartupNotification(mainApp));
+    }
+
+    @Test
+    public void setPastMeetingNotification_saveFails_setsNotification() throws Exception {
+        MainApp mainApp = createMainApp();
+        setField(mainApp, "storage", new StorageManager(
+                new JsonAddressBookStorage(temporaryFolder.resolve("ab.json")) {
+                    @Override
+                    public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
+                        throw new IOException("save failed");
+                    }
+                },
+                new JsonUserPrefsStorage(temporaryFolder.resolve("prefs.json"))));
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(temporaryFolder.resolve("ab.json")) {
+            @Override
+            public int getRemovedPastMeetingCount() {
+                return 1;
+            }
+        };
+
+        invokeSetPastMeetingNotification(mainApp, addressBookStorage);
+
+        assertEquals("1 past meeting(s) removed.", getStartupNotification(mainApp));
+    }
+
+    private MainApp createMainApp() throws Exception {
+        MainApp mainApp = new MainApp();
+        setField(mainApp, "model", new ModelManager());
+        setField(mainApp, "storage", new StorageManager(
+                new JsonAddressBookStorage(temporaryFolder.resolve("ab.json")),
+                new JsonUserPrefsStorage(temporaryFolder.resolve("prefs.json"))));
+        return mainApp;
+    }
+
+    private void invokeSetPastMeetingNotification(MainApp mainApp, JsonAddressBookStorage addressBookStorage)
+            throws Exception {
+        Method method = MainApp.class.getDeclaredMethod("setPastMeetingNotification", JsonAddressBookStorage.class);
+        method.setAccessible(true);
+        method.invoke(mainApp, addressBookStorage);
+    }
+
+    private void setField(MainApp mainApp, String fieldName, Object value) throws Exception {
+        Field field = MainApp.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mainApp, value);
+    }
+
+    private String getStartupNotification(MainApp mainApp) throws Exception {
+        Field field = MainApp.class.getDeclaredField("startupNotification");
+        field.setAccessible(true);
+        return (String) field.get(mainApp);
+    }
+}

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -54,6 +54,9 @@ public class LogicManagerTest {
         if (DeleteCommand.hasPendingConfirmation()) {
             DeleteCommand.confirmationCommand(model, "n");
         }
+        if (ClearCommand.hasPendingConfirmation()) {
+            ClearCommand.confirmationCommand(model, "n");
+        }
         JsonAddressBookStorage addressBookStorage =
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
@@ -237,6 +240,20 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_deleteInvalidConfirmation_locksCommands() throws Exception {
+        String deleteCommand = "delete 12345678";
+        Person personToDelete = new PersonBuilder(AMY).withTags().withDetails("")
+                .withPhone("12345678").build();
+        model.addPerson(personToDelete);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(deleteCommand,
+                String.format(DeleteCommand.MESSAGE_CONFIRMATION_PROMPT, personToDelete.getName()), expectedModel);
+        assertCommandSuccess(ListCommand.COMMAND_WORD, DeleteCommand.MESSAGE_CONFIRMATION_REQUIRED, expectedModel);
+        assertCommandSuccess("n", DeleteCommand.MESSAGE_DELETION_CANCELLED, expectedModel);
+    }
+
+    @Test
     public void execute_clearCommand_withConfirmation() throws Exception {
         String clearCommand = ClearCommand.COMMAND_WORD;
         String confirmCommand = "y";
@@ -270,6 +287,17 @@ public class LogicManagerTest {
 
         assertCommandSuccess(clearCommand, expectedConfirmationMessage, expectedModel);
         assertCommandSuccess(confirmCommand, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_clearInvalidConfirmation_locksCommands() throws Exception {
+        Person person = new PersonBuilder(AMY).withTags().withDetails("").build();
+        model.addPerson(person);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(ClearCommand.COMMAND_WORD, ClearCommand.MESSAGE_CONFIRMATION_PROMPT, expectedModel);
+        assertCommandSuccess(ListCommand.COMMAND_WORD, ClearCommand.MESSAGE_CONFIRMATION_REQUIRED, expectedModel);
+        assertCommandSuccess("n", ClearCommand.MESSAGE_CLEAR_CANCELLED, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -91,6 +91,11 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void modifiesAddressBook_returnsTrue() {
+        assertTrue(new DeleteCommand(ALICE.getPhone()).modifiesAddressBook());
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteAliceCommand = new DeleteCommand(ALICE.getPhone());
         DeleteCommand deleteBensonCommand = new DeleteCommand(BENSON.getPhone());

--- a/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
@@ -106,6 +106,25 @@ public class MeetingCommandTest {
     }
 
     @Test
+    public void execute_clearNoMeeting_returnsNoMeetingMessage() throws Exception {
+        Model actualModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        int zeroBasedIndex = 0;
+        while (expectedModel.getFilteredPersonList().get(zeroBasedIndex).hasMeeting()) {
+            zeroBasedIndex++;
+        }
+        Index index = Index.fromZeroBased(zeroBasedIndex);
+
+        Person personToEdit = expectedModel.getFilteredPersonList().get(index.getZeroBased());
+        MeetingCommand command = MeetingCommand.clear(index);
+        CommandResult commandResult = command.execute(actualModel);
+
+        assertEquals(String.format(MeetingCommand.MESSAGE_NO_MEETINGS, personToEdit.getName()),
+                commandResult.getFeedbackToUser());
+        assertEquals(expectedModel, actualModel);
+    }
+
+    @Test
     public void execute_nullModel_throwsNullPointerException() {
         Meeting meeting = new Meeting(LocalDateTime.of(2030, 3, 25, 14, 30));
         MeetingCommand meetingCommand = new MeetingCommand(Index.fromOneBased(1), meeting);

--- a/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
@@ -140,6 +140,12 @@ public class MeetingCommandTest {
     }
 
     @Test
+    public void modifiesAddressBook_returnsTrue() {
+        Meeting meeting = new Meeting(LocalDateTime.of(2030, 3, 25, 14, 30));
+        assertTrue(new MeetingCommand(Index.fromOneBased(1), meeting).modifiesAddressBook());
+    }
+
+    @Test
     public void getFormattedDateAndTime_returnsExpectedFormat() {
         Meeting meeting = new Meeting(LocalDateTime.of(2030, 3, 25, 14, 30));
         MeetingCommand meetingCommand = new MeetingCommand(Index.fromOneBased(1), meeting);

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -179,6 +180,7 @@ public class JsonAdaptedPersonTest {
                 NOT_FAVOURITE, "2020-01-01T10:00");
         Person modelPerson = person.toModelType();
         assertFalse(modelPerson.hasMeeting());
+        assertTrue(person.hasRemovedPastMeeting());
     }
 
 

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -84,6 +85,25 @@ public class JsonAddressBookStorageTest {
         readBack = jsonAddressBookStorage.readAddressBook().get(); // file path not specified
         assertEquals(original, new AddressBook(readBack));
 
+    }
+
+    @Test
+    public void readAddressBook_pastMeeting_countRemovedMeeting() throws Exception {
+        Path filePath = testFolder.resolve("PastMeetingAddressBook.json");
+        Files.writeString(filePath, "{ \"persons\" : [ {"
+                + "\"name\" : \"Alice Pauline\","
+                + "\"phone\" : \"94351253\","
+                + "\"email\" : \"alice@example.com\","
+                + "\"address\" : \"123, Jurong West Ave 6, #08-111\","
+                + "\"tags\" : [ \"Renter\" ],"
+                + "\"meeting\" : \"2020-01-01T10:00\""
+                + "} ] }");
+        JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(filePath);
+
+        ReadOnlyAddressBook readBack = jsonAddressBookStorage.readAddressBook().get();
+
+        assertEquals(1, jsonAddressBookStorage.getRemovedPastMeetingCount());
+        assertFalse(readBack.getPersonList().get(0).hasMeeting());
     }
 
     @Test


### PR DESCRIPTION
Adds a startup result message when past meetings are removed from saved data, so users are informed instead of the cleanup happening silently. Also improves meeting clearing and confirmation flows by returning a clear “no meeting to clear” message when applicable, and by warning users that commands are locked while delete/clear confirmation is pending unless they enter y or n.


Fixes Issues#236, 235, 228, 211, 208, 207, 199