### PR TITLE
Update documentation for command behavior and planned enhancements

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -105,7 +105,7 @@ How the `Logic` component works:
 
 1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.
 1. This results in a `Command` object (more precisely, an object of one of its subclasses e.g., `DeleteCommand`) which is handled by the `LogicManager`.
-1. For commands that require confirmation, such as `delete` and `clear`, `LogicManager` first returns a confirmation prompt and waits for the user to enter `y` or `n`.
+1. For commands that require confirmation, such as `delete` and `clear`, `LogicManager` first returns a confirmation prompt and waits for the user to enter `y` or `n`. Confirmation input is case-insensitive, so `y`, `Y`, `n`, and `N` are accepted.
 1. Once confirmed, the command can communicate with the `Model` when it is executed (e.g. to delete a person).<br>
    Note that although this is shown as a single step in the diagram above (for simplicity), in the code it can take several interactions (between the command object and the `Model`) to achieve.
 1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`.
@@ -454,7 +454,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 1.  User requests to delete a specific person by phone number.
 2.  CLIentTracker asks for confirmation.
-3.  User confirms the deletion.
+3.  User confirms the deletion using `y` or `Y`.
 4.  CLIentTracker deletes the person.
 
     Use case ends.
@@ -467,7 +467,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case ends.
 
-* 2a. The user cancels the deletion.
+* 2a. The user cancels the deletion using `n` or `N`.
 
   * 2a1. CLIentTracker shows a cancellation message.
 
@@ -534,7 +534,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 1. User requests to clear all contacts.
 2. CLIentTracker asks for confirmation.
-3. User confirms the clear command.
+3. User confirms the clear command using `y` or `Y`.
 4. CLIentTracker clears all contacts.
 5. CLIentTracker shows a confirmation message.
 
@@ -542,7 +542,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-* 2a. The user cancels the clear command.
+* 2a. The user cancels the clear command using `n` or `N`.
 
   * 2a1. CLIentTracker shows a cancellation message.
 
@@ -740,10 +740,10 @@ testers are expected to do more *exploratory* testing.
    1. Prerequisites: Ensure a contact with phone number `81234567` exists. If not, add one using
       `add n/Delete Me p/81234567`.
 
-   1. Test case: `delete 81234567`, followed by `y`<br>
+   1. Test case: `delete 81234567`, followed by `y` or `Y`<br>
       Expected: The contact is deleted. A success message is shown and the person disappears from the displayed list.
 
-   1. Test case: `delete 81234567`, followed by `n`<br>
+   1. Test case: `delete 81234567`, followed by `n` or `N`<br>
       Expected: The deletion is cancelled. The contact list remains unchanged.
 
    1. Test case: `delete 00000000`<br>
@@ -758,10 +758,10 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: The list contains at least one person.
 
-   1. Test case: `clear`, followed by `n`<br>
+   1. Test case: `clear`, followed by `n` or `N`<br>
       Expected: The clear operation is cancelled. The contact list remains unchanged.
 
-   1. Test case: `clear`, followed by `y`<br>
+   1. Test case: `clear`, followed by `y` or `Y`<br>
       Expected: All contacts are removed from the list. A success message is shown.
 
 ### Marking and unmarking favourites
@@ -855,3 +855,15 @@ testers are expected to do more *exploratory* testing.
       Expected: The application starts with an empty address book and creates a fresh valid data file.
 
    1. Restore the backup copy after testing.
+
+--------------------------------------------------------------------------------------------------------------------
+
+## **Appendix: Planned Enhancements**
+
+Team size: 5
+
+1. Allow contact deletion by displayed index: The current `delete` command only deletes a contact by full phone number, e.g. `delete 91234567`. We plan to also allow deletion by the displayed list index, e.g. `delete 1`, so users can delete a contact directly after using commands such as `list`, `find`, or `favourites` without copying the phone number.
+
+1. Allow multiple meetings per contact: The current `meeting` command stores only one meeting per contact, so adding a new meeting replaces the existing meeting. We plan to allow each contact to store multiple meetings, e.g. `meeting 1 15 Mar 2030 4pm` followed by `meeting 1 20 Mar 2030 2pm` would keep both meetings for the first displayed contact instead of replacing the first one.
+
+1. Allow phone numbers from other countries: The current phone number validation only accepts local Singapore phone numbers. We plan to allow phone numbers with country codes, e.g. `+60 123456789` or `+1 2125551234`, so users can store contacts from other countries without removing the country code.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -55,8 +55,8 @@ still having a clean desktop interface.
 
    * `list` to list all contacts
    * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01` to add a contact
-   * `delete 3` to delete the 3rd displayed contact
-   * `clear` to delete all contacts
+   * `delete 87438807` to delete the contact with the phone number `87438807` (`y` to confirm deletion)
+   * `clear` to delete all contacts (`y` to confirm clear)
    * `find n/John` to search for contacts by name
    * `exit` to close the application
 
@@ -84,8 +84,10 @@ Want to start fresh? Use `clear` and confirm with `y` to remove the sample conta
   * Parameters can be in any order.<br>
     *  e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-  * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+  * Extraneous parameters for `help`, `list`, `exit`, `favourites`, and `undo` will be ignored.<br>
     * e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+  * `clear` does not accept trailing arguments.<br>
+    * e.g. `clear` and `clear   ` are accepted, but `clear 123` is invalid.
 
   * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
@@ -347,7 +349,7 @@ Format: `delete PHONE`
 * Deletes the person with `PHONE`.
   * The PHONE refers to the index number shown in the displayed person list.
   * The PHONE **must match fully** ​
-  * Confirm with y/n after delete command was entered
+  * Confirm with `y`/`n` after the delete command is entered. Confirmation input is case-insensitive, so `y`, `Y`, `n`, and `N` are accepted.
 
 Examples:
 * `delete 91234567` deletes the person with said phone number in CLIentTracker.
@@ -358,7 +360,8 @@ Examples:
 ### Clearing all entries : `clear`
 
 Deletes all entries from CLIentTracker, including favourites. 
-* Confirm with y/n after clear command was entered
+* Confirm with `y`/`n` after the clear command is entered. Confirmation input is case-insensitive, so `y`, `Y`, `n`, and `N` are accepted.
+* `clear` only works without trailing arguments. `clear` and `clear   ` are accepted, but `clear 123` is invalid.
 
 Format: `clear`
 
@@ -388,6 +391,7 @@ Format: `undo`
 
 * Restores the contact list to its previous state before the last modifying command
 * If there are no previous changes to undo in the current session, an error message is shown
+* `undo` works with or without trailing arguments. Any trailing arguments are ignored.
 
 ---
 
@@ -396,6 +400,8 @@ Format: `undo`
 Shows a list of all persons in CLIentTracker.
 
 Format: `list`
+
+* `list` works with or without trailing arguments. Any trailing arguments are ignored.
 
 ---
 
@@ -406,6 +412,8 @@ Displays a list containing only contacts marked as favourites. Favourite contact
 ![favourites message](images/favourites.png)
 
 Format: `favourites`
+
+* `favourites` works with or without trailing arguments. Any trailing arguments are ignored.
 
 ---
 
@@ -418,6 +426,8 @@ The user can open their preferred browser and paste the provided URL to access i
 
 Format: `help`
 
+* `help` works with or without trailing arguments. Any trailing arguments are ignored.
+
 ---
 
 ### Exiting the program: `exit`
@@ -425,6 +435,8 @@ Format: `help`
 Exits the program.
 
 Format: `exit`
+
+* `exit` works with or without trailing arguments. Any trailing arguments are ignored.
 
 ---
 


### PR DESCRIPTION
Clarifies command behavior in the User Guide and Developer Guide, including case-insensitive y/n confirmations, trailing-argument handling for no-argument commands, and clear rejecting non-whitespace trailing arguments. Adds a Planned Enhancements appendix to the Developer Guide covering deletion by displayed index, multiple meetings per contact, and international phone numbers with country codes.

Fixes Issues#244, 232, 226, 218, 212, 194, 193, 191, 190, 189, 188, 187, 186