### PR TITLE
Update help and email formatting feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,13 @@ mainClassName = 'seedu.address.Main'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
+
+
 repositories {
     mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
+
+
 
 checkstyle {
     toolVersion = '11.0.0'

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,7 +120,8 @@ Format: `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAG]…�
 Parameters:
 * `p/` : Phone number of the new contact (*Unique identifier*)
 * `n/` : Name of the new contact (*Must be 1-50 characters*)
-* `e/` : Email of the new contact [optional] (*Must be 2-254 characters, or empty to represent no email*)
+* `e/` : Email of the new contact [optional]
+  - Must follow the [Email rules](#email-rules)
 * `a/` : Address of the new contact [optional] (*Must be 1-255 characters, or empty to represent no address*)
 * `d/` : Details of the new contact [optional] (*Must be under 512 characters, or empty to represent no details*)
 * `t/` : Tags of the new contact [optional] (*Valid tags: "Renter", "Landlord", "Buyer", "Seller"*)
@@ -134,10 +135,10 @@ Behavior:
 * Name must be 1-50 characters and contain only alphanumeric characters and spaces.
 * Details will default to empty if parameter not used.
 * Details must not be over 512 characters and cannot be empty.
-* Email will default to empty if parameter not used.
-* Email must be 2-254 characters if provided, or empty to represent no email.
 * Address will default to empty if parameter not used.
 * Address must be 1-255 characters if provided, or empty to represent no address.
+
+
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
@@ -158,7 +159,8 @@ Parameters:
 * `INDEX` : The index of the person to edit. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * `p/` : Phone number of the new contact (*Unique identifier*)
 * `n/` : Name of the new contact (*Must be 1-50 characters*)
-* `e/` : Email of the new contact [optional] (*Must be 2-254 characters, or empty to represent no email*)
+* `e/` : Email of the contact [optional]
+  - Must follow the [Email rules](#email-rules)
 * `a/` : Address of the new contact [optional] (*Must be 1-255 characters, or empty to represent no address*)
 * `d/` : Details of the new contact [optional] (*Must be under 512 characters, or empty to represent no details*)
 * `t/` : Tags of the new contact [optional] (*Valid tags: "Renter", "Landlord", "Buyer", "Seller"*)
@@ -456,6 +458,29 @@ If your changes to the data file makes its format invalid, CLIentTracker will di
 Furthermore, certain edits can cause CLIentTracker to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </div>
 
+---
+
+### Email {: #email-rules }
+
+Emails must follow the format `local-part@domain`.
+
+#### Format rules
+- The local-part:
+  - May contain alphanumeric characters and `+ - . _`
+  - Parentheses (`(` and `)`) are not allowed
+  - Must not start or end with a special character
+- The `@` symbol separates the local-part and the domain
+
+#### Domain rules
+- The domain consists of labels separated by periods (`.`)
+- Each label:
+  - Is at least 2 characters long
+  - Starts and ends with an alphanumeric character
+  - May contain hyphens (`-`) in between
+
+#### Length and optionality
+- Email length must be between **1 and 254 characters**
+- If the email parameter is omitted or left empty (`e/`), the contact will have **no email**
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -413,6 +413,7 @@ Format: `favourites`
 
 Shows a message explaining how to access the help page
 The user can open their preferred browser and paste the provided URL to access it
+They can also manually close the help window by clicking the close button or pressing the Escape key.
 
 ![help message](images/helpMessage.png)
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -7,6 +7,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -20,7 +22,7 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String COMMAND_SUMMARY =
         "Quick Command Summary:\n\n"
         + "• add n/NAME p/PHONE [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAGS]\n"
-        + "• edit INDEX [p/PHONE] [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAGS]\n"
+        + "• edit INDEX [p/PHONE] [n/NAME] [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAGS]\n"
         + "• delete PHONE\n"
         + "• clear\n"
         + "• list\n"
@@ -45,21 +47,37 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private Label helpMessage;
 
+    private final Runnable onEscapePressed;
+
     /**
      * Creates a new HelpWindow.
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpWindow(Stage root, Runnable onEscapePressed) {
         super(FXML, root);
+        this.onEscapePressed = onEscapePressed;
         helpMessage.setText(COMMAND_SUMMARY + HELP_MESSAGE);
+        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ESCAPE) {
+                this.onEscapePressed.run();
+                event.consume();
+            }
+        });
+    }
+
+    /**
+     * Creates a new HelpWindow.
+     */
+    public HelpWindow(Runnable onEscapePressed) {
+        this(new Stage(), onEscapePressed);
     }
 
     /**
      * Creates a new HelpWindow.
      */
     public HelpWindow() {
-        this(new Stage());
+        this(new Stage(), () -> { });
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -65,7 +65,7 @@ public class MainWindow extends UiPart<Stage> {
 
         setAccelerators();
 
-        helpWindow = new HelpWindow();
+        helpWindow = new HelpWindow(this::handleHelpWindowEscape);
     }
 
     public Stage getPrimaryStage() {
@@ -149,6 +149,12 @@ public class MainWindow extends UiPart<Stage> {
             helpWindow.show();
         } else {
             helpWindow.focus();
+        }
+    }
+
+    private void handleHelpWindowEscape() {
+        if (helpWindow.isShowing()) {
+            helpWindow.hide();
         }
     }
 


### PR DESCRIPTION
This update aligns the help feature with the User Guide and improves overall usability.

### Changes
- Updated the `edit` command format displayed in the help window to match the User Guide:
  - From:  
    `edit INDEX [p/PHONE] [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAGS]`
  - To:  
    `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [d/DETAILS] [t/TAG]`
- Added support for closing the help window using the Escape key
- Updated the User Guide to reflect these changes

Refined the email rules in the User Guide to improve clarity and user-friendliness.