### PR TITLE
Add confirmation-lock handling, clearer meeting cleanup behavior, and…

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -867,3 +867,5 @@ Team size: 5
 1. Allow multiple meetings per contact: The current `meeting` command stores only one meeting per contact, so adding a new meeting replaces the existing meeting. We plan to allow each contact to store multiple meetings, e.g. `meeting 1 15 Mar 2030 4pm` followed by `meeting 1 20 Mar 2030 2pm` would keep both meetings for the first displayed contact instead of replacing the first one.
 
 1. Allow phone numbers from other countries: The current phone number validation only accepts local Singapore phone numbers. We plan to allow phone numbers with country codes, e.g. `+60 123456789` or `+1 2125551234`, so users can store contacts from other countries without removing the country code.
+
+1. Notify users when past meetings are removed: The current meeting cleanup removes past meetings when the app opens, but users are not explicitly notified when this happens. We plan to display a startup notification such as `1 past meeting(s) removed.` when past meetings are removed from saved contact data.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -54,7 +54,7 @@ public class LogicManager implements Logic {
         if (DeleteCommand.hasPendingConfirmation()) {
             AddressBook previousState = null;
             String executedCommandText = null;
-            if (commandText.equalsIgnoreCase("y")) {
+            if (commandText.trim().equalsIgnoreCase("y")) {
                 previousState = new AddressBook(model.getAddressBook());
                 executedCommandText = DeleteCommand.getPendingCommandText();
             }
@@ -69,7 +69,7 @@ public class LogicManager implements Logic {
         if (ClearCommand.hasPendingConfirmation()) {
             AddressBook previousState = null;
             String executedCommandText = null;
-            if (commandText.equalsIgnoreCase("y")) {
+            if (commandText.trim().equalsIgnoreCase("y")) {
                 previousState = new AddressBook(model.getAddressBook());
                 executedCommandText = ClearCommand.getPendingCommandText();
             }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,7 +18,8 @@ public class ClearCommand extends Command {
             + "Example: " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_CONFIRMATION_PROMPT = "Are you sure you want to clear your contact book? (y/n)";
-    public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please enter 'y' to confirm or 'n' to cancel.";
+    public static final String MESSAGE_CONFIRMATION_REQUIRED =
+            "All commands are locked until confirmation is done. Please enter 'y' to confirm or 'n' to cancel.";
     public static final String MESSAGE_CLEAR_CANCELLED = "Clear cancelled.";
 
     private static ClearCommand pendingClearCommand;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -25,7 +25,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_PHONE_NOT_FOUND = "No person found with this specific phone number: %1$s";
     public static final String MESSAGE_CONFIRMATION_PROMPT = "Are you sure you want to delete this contact? %1$s (y/n)";
-    public static final String MESSAGE_CONFIRMATION_REQUIRED = "Please enter 'y' to confirm or 'n' to cancel.";
+    public static final String MESSAGE_CONFIRMATION_REQUIRED =
+            "All commands are locked until confirmation is done. Please enter 'y' to confirm or 'n' to cancel.";
     public static final String MESSAGE_DELETION_CANCELLED = "Deletion cancelled.";
 
     private static DeleteCommand pendingDeleteCommand;

--- a/src/main/java/seedu/address/logic/commands/MeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetingCommand.java
@@ -30,6 +30,7 @@ public class MeetingCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 25/03/2030 14:30\n"
             + "Example: " + COMMAND_WORD + " 1 " + CLEAR_KEYWORD + "\n"
             + DateTimeUtil.MESSAGE_INVALID_DATE_TIME_FORMAT;
+    public static final String MESSAGE_NO_MEETINGS = "There are currently no scheduled meetings for %1$s";
 
     private final Index index;
     private final Meeting meeting;
@@ -87,6 +88,10 @@ public class MeetingCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        if (isClearMeeting && !personToEdit.hasMeeting()) {
+            return new CommandResult(String.format(MESSAGE_NO_MEETINGS, personToEdit.getName()));
+        }
+
         Person updatedPerson = new Person(
                 personToEdit.getName(),
                 personToEdit.getPhone(),

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -54,6 +54,9 @@ public class LogicManagerTest {
         if (DeleteCommand.hasPendingConfirmation()) {
             DeleteCommand.confirmationCommand(model, "n");
         }
+        if (ClearCommand.hasPendingConfirmation()) {
+            ClearCommand.confirmationCommand(model, "n");
+        }
         JsonAddressBookStorage addressBookStorage =
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
@@ -237,6 +240,22 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_deleteInvalidConfirmation_locksCommands() throws Exception {
+        String deleteCommand = "delete 12345678";
+
+        Person personToDelete = new PersonBuilder(AMY).withTags().withDetails("")
+                .withPhone("12345678").build();
+        model.addPerson(personToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(deleteCommand,
+                String.format(DeleteCommand.MESSAGE_CONFIRMATION_PROMPT, personToDelete.getName()), expectedModel);
+        assertCommandSuccess(ListCommand.COMMAND_WORD, DeleteCommand.MESSAGE_CONFIRMATION_REQUIRED, expectedModel);
+        assertCommandSuccess("n", DeleteCommand.MESSAGE_DELETION_CANCELLED, expectedModel);
+    }
+
+    @Test
     public void execute_clearCommand_withConfirmation() throws Exception {
         String clearCommand = ClearCommand.COMMAND_WORD;
         String confirmCommand = "y";
@@ -270,6 +289,20 @@ public class LogicManagerTest {
 
         assertCommandSuccess(clearCommand, expectedConfirmationMessage, expectedModel);
         assertCommandSuccess(confirmCommand, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_clearInvalidConfirmation_locksCommands() throws Exception {
+        String clearCommand = ClearCommand.COMMAND_WORD;
+
+        Person person = new PersonBuilder(AMY).withTags().withDetails("").build();
+        model.addPerson(person);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(clearCommand, ClearCommand.MESSAGE_CONFIRMATION_PROMPT, expectedModel);
+        assertCommandSuccess(ListCommand.COMMAND_WORD, ClearCommand.MESSAGE_CONFIRMATION_REQUIRED, expectedModel);
+        assertCommandSuccess("n", ClearCommand.MESSAGE_CLEAR_CANCELLED, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -91,6 +91,11 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void modifiesAddressBook_returnsTrue() {
+        assertTrue(new DeleteCommand(ALICE.getPhone()).modifiesAddressBook());
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteAliceCommand = new DeleteCommand(ALICE.getPhone());
         DeleteCommand deleteBensonCommand = new DeleteCommand(BENSON.getPhone());

--- a/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MeetingCommandTest.java
@@ -106,6 +106,25 @@ public class MeetingCommandTest {
     }
 
     @Test
+    public void execute_clearNoMeeting_returnsNoMeetingMessage() throws Exception {
+        Model actualModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        int zeroBasedIndex = 0;
+        while (expectedModel.getFilteredPersonList().get(zeroBasedIndex).hasMeeting()) {
+            zeroBasedIndex++;
+        }
+        Index index = Index.fromZeroBased(zeroBasedIndex);
+        Person personToEdit = expectedModel.getFilteredPersonList().get(index.getZeroBased());
+
+        MeetingCommand command = MeetingCommand.clear(index);
+        CommandResult commandResult = command.execute(actualModel);
+
+        assertEquals(String.format(MeetingCommand.MESSAGE_NO_MEETINGS, personToEdit.getName()),
+                commandResult.getFeedbackToUser());
+        assertEquals(expectedModel, actualModel);
+    }
+
+    @Test
     public void execute_nullModel_throwsNullPointerException() {
         Meeting meeting = new Meeting(LocalDateTime.of(2030, 3, 25, 14, 30));
         MeetingCommand meetingCommand = new MeetingCommand(Index.fromOneBased(1), meeting);
@@ -126,6 +145,12 @@ public class MeetingCommandTest {
         MeetingCommand meetingCommand = new MeetingCommand(Index.fromOneBased(1), meeting);
 
         assertEquals("25 Mar 2030 2:30 pm", meeting.getFormattedDateTime());
+    }
+
+    @Test
+    public void modifiesAddressBook_returnsTrue() {
+        Meeting meeting = new Meeting(LocalDateTime.of(2030, 3, 25, 14, 30));
+        assertTrue(new MeetingCommand(Index.fromOneBased(1), meeting).modifiesAddressBook());
     }
 
     @Test


### PR DESCRIPTION
•Displaying a clearer message when users enter other commands during clear or delete confirmation: all commands are locked until confirmation is completed.
•Supporting confirmation inputs with surrounding whitespace, e.g. y and n.
•Returning a “no scheduled meetings” message when users run meeting INDEX clear on a contact without a meeting.
•Adding tests for confirmation locking, clear-with-no-meeting behavior, and address book modification coverage.
•Adding a DG planned enhancement that past meetings are currently removed on app open, and future iterations will notify users when that cleanup happens.

Fixed Issues#236, 235, 228, 211, 208, 207, 199