### PR TITLE
Clarify favourites command error message when list is empty

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FavouritesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouritesCommand.java
@@ -2,7 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
  * Lists all favourite persons in the address book to the user.
@@ -12,10 +14,16 @@ public class FavouritesCommand extends Command {
     public static final String COMMAND_WORD = "favourites";
 
     public static final String MESSAGE_SUCCESS = "Listed all favourite persons";
+    public static final String MESSAGE_NO_FAVOURITES =
+            "No contacts are marked as favourites. Use the mark command to add favourites first.";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        boolean hasFavouriteContacts = model.getAddressBook().getPersonList().stream().anyMatch(Person::getIsFavourite);
+        if (!hasFavouriteContacts) {
+            throw new CommandException(MESSAGE_NO_FAVOURITES);
+        }
         model.updateFilteredPersonList(person -> person.getIsFavourite());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/test/java/seedu/address/logic/commands/FavouritesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouritesCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -28,9 +29,8 @@ public class FavouritesCommandTest {
     }
 
     @Test
-    public void execute_noFavourites_showsEmptyList() {
-        expectedModel.updateFilteredPersonList(person -> person.getIsFavourite());
-        assertCommandSuccess(new FavouritesCommand(), model, FavouritesCommand.MESSAGE_SUCCESS, expectedModel);
+    public void execute_noFavourites_throwsCommandException() {
+        assertCommandFailure(new FavouritesCommand(), model, FavouritesCommand.MESSAGE_NO_FAVOURITES);
     }
 
     @Test


### PR DESCRIPTION
This PR improves the error message shown when the `favourites` command is used while no contacts have been marked as favourites.

### Before
The error message was unclear and did not guide users on how to resolve the issue.
<img width="1683" height="485" alt="image" src="https://github.com/user-attachments/assets/195d587a-b5be-4ea2-aaaa-5d9a1624c916" />

### After
Users are informed that no contacts are currently marked as favourites and are prompted to use the `mark` command to add favourites.

<img width="1637" height="304" alt="image" src="https://github.com/user-attachments/assets/8fcf6c50-1cfe-4857-a005-f15fcbc81115" />
