### PR TITLE
Fix mismatch between tag error message and User Guide

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tag must be of Renter, Landlord, buyer or seller only";
+    public static final String MESSAGE_CONSTRAINTS = "Invalid tag. Valid tags are: Renter, Landlord, Buyer, Seller.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final ClientTag tagName;


### PR DESCRIPTION
Ensured the invalid tag error message uses the same wording as the User Guide
for valid tag values (Renter, Landlord, Buyer, Seller).